### PR TITLE
Ensure append-hook only runs once using a key on the element

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,17 @@
 var Hook = require('virtual-hook')
 var nextTick = require('next-tick')
 var partial = require('ap').partial
-var document = require('global/document')
+
+var key = '__APPEND_HOOK_KEY'
 
 module.exports = AppendHook
 
 function AppendHook (callback) {
   return Hook({
     hook: function hook (node) {
-      if (document.body.contains(node)) return
+      if (node[key]) return
+
+      node[key] = true
       nextTick(partial(callback, node))
     }
   })

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "append"
   ],
   "devDependencies": {
-    "proxyquire": "~1.7.1",
     "standard": "^4.0.0",
     "tape": "^4.0.0",
     "virtual-dom": "~2.1.1"
@@ -30,7 +29,6 @@
   ],
   "dependencies": {
     "ap": "~0.2.0",
-    "global": "~4.3.0",
     "next-tick": "~0.2.2",
     "virtual-hook": "~1.0.1"
   }


### PR DESCRIPTION
Problem: When rendering from the server, all of an app's elements already exist in the DOM.

This means that when append-hook runs initially, `document.body.contains` returns true and the hook's callback never gets called.

With this change, we're guaranteed to run append-hook only once per node, without relying on the body's state.

[ev-store](https://github.com/Raynos/ev-store) uses this same method (a key on the node) to keep track of listeners.
