### PR TITLE
Support multiple append hooks on one node

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,14 @@ var Hook = require('virtual-hook')
 var nextTick = require('next-tick')
 var partial = require('ap').partial
 
-var key = '__APPEND_HOOK_KEY'
+var KEY = '__APPEND_HOOK_KEY__'
 
 module.exports = AppendHook
 
 function AppendHook (callback) {
   return Hook({
-    hook: function hook (node) {
+    hook: function hook (node, vnodeKey) {
+      var key = KEY + vnodeKey
       if (node[key]) return
 
       node[key] = true

--- a/test.js
+++ b/test.js
@@ -28,3 +28,13 @@ test(function (t) {
     patch(element, diff(vtree, vtree2))
   }
 })
+
+test('multiple append hooks on one node', function (t) {
+  t.plan(2)
+  var vtree = h('div', {
+    hook1: Append(() => t.pass('hook1')),
+    hook2: Append(() => t.pass('hook2'))
+  })
+
+  createElement(vtree)
+})


### PR DESCRIPTION
Use case: composition of two components. One component has a hook that deals with its private implementation, but its parent _also_ has a hook that uses it in a certain way.

``` js
function renderHeader (state, options) {
  options = extend({
    firstAppendHook: AppendHook(state.hooks.something)
  }, options || {})
}

renderHeader(state.header, {
  anotherAppendHook: AppendHook(state.hooks.somethingElse)
})
```
